### PR TITLE
Make polling default to true to match previous behaviour

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -30,7 +30,7 @@ module.exports = {
 				id: 'polling',
 				label: 'Enable Polling',
 				width: 12,
-				default: false,
+				default: true,
 			},
 			{
 				type: 'static-text',


### PR DESCRIPTION
Given the polling setting used to be ignored entirely and a chunk of the feedback from external control won't work without it.