### PR TITLE
Add support for HTTPS calls

### DIFF
--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -6,7 +6,7 @@ This module will allow you to control Sony Bravia TVs such as the FWD-65X950G.
 
 - The remote device must be configured to use a PSK.
 - Go into Network and Internet > Local network setup > IP Control. Change Authentication to Pre-Shared Key and set the PSK in Pre-Shared Key.
-- The module makes HTTP requests over port 80.
+- The module can be configured to make HTTP (port 80) or HTTPS (port 443) requests.
 - To allow power on, go into Network and Internet > Remote start > On (Powered on by apps)
 
 ### To use the module

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "sony-bravia",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"main": "index.js",
 	"scripts": {
 		"format": "prettier -w .",

--- a/src/api.js
+++ b/src/api.js
@@ -68,10 +68,19 @@ module.exports = {
 				},
 			}
 
-			let client = new Client()
+			const clientOptions = {};
+			if (self.config.protocols === 'https' && !!self.config.allowUnauthorizedCertificates) {
+				clientOptions.connection = {
+					rejectUnauthorized: false,
+				}
+			}
+
+			let client = new Client(clientOptions)
+
+			const protocol = self.config.protocols || 'http'
 
 			client
-				.post(`http://${self.config.host}/sony/${service}`, args, function (data, response) {
+				.post(`${protocol}://${self.config.host}/sony/${service}`, args, function (data, response) {
 					//do something with response
 					try {
 						if (response.statusCode == 200) {

--- a/src/config.js
+++ b/src/config.js
@@ -26,6 +26,17 @@ module.exports = {
 				width: 6,
 			},
 			{
+				type: 'dropdown',
+				id: 'protocols',
+				label: 'Protocol',
+				width: 6,
+				default: 'http',
+				choices: [
+					{ id: 'http', label: 'HTTP' },
+					{ id: 'https', label: 'HTTPS' }
+				]
+			},
+			{
 				type: 'checkbox',
 				id: 'polling',
 				label: 'Enable Polling',
@@ -64,6 +75,27 @@ module.exports = {
 				id: 'verbose',
 				label: 'Enable Verbose Logging',
 				default: false,
+			},
+			{
+				type: 'checkbox',
+				id: 'allowUnauthorizedCertificates',
+				label: 'Allow Unauthorized Certificates',
+				width: 6,
+				default: false,
+				isVisible: (configValues) => configValues.protocols === 'https',
+			},
+			{
+				type: 'static-text',
+				id: 'allowUnauthorizedCertificatesInfo',
+				width: 12,
+				value: `
+						<h6>WARNING</h6>
+						<p>
+							This option is only for development purposees. We DO NOT recommend turning on this option in production.
+						</p>
+						<hr />
+					`,
+				isVisible: (configValues) => configValues.protocols === 'https' && configValues.allowUnauthorizedCertificates === true,
 			},
 		]
 	},


### PR DESCRIPTION
Add support for making api calls via HTTPS. Also included an option to disable the rejecting of unauthorized requests (due to bravia TVs using self signed certificates)